### PR TITLE
Fixed that problem where pathfinding jumps down to first floor then b…

### DIFF
--- a/src/main/java/textDirections/MakeDirections.java
+++ b/src/main/java/textDirections/MakeDirections.java
@@ -47,9 +47,14 @@ public class MakeDirections {
             //System.out.println(direction);
 
             if(currentNode.getLocation().getFloor() != nextNode.getLocation().getFloor()) {
+                if(nextNode.getLocation().getFloor() == myPath.get(myPath.size()-1).getLocation().getFloor()){
+                    output2 = output.concat("Take elevator to floor: " + nextNode.getLocation().getFloor() + "\n");
+                    output = output2;
+                }
+                //else These aren't the droids you're looking for. Ignore this node. It's a lie!
+                //Assuming we'll never start on floor five, go to floor 4, jump to 1, go back to 4.
                 //System.out.println("Made it here");
-                output2 = output.concat("Take elevator to floor: " + nextNode.getLocation().getFloor() + "\n");
-                output = output2;
+
             }
 
             else {


### PR DESCRIPTION
…ack up. I didn't fix it in A*; I just made it so that we skip nodes that aren't on the destination floor when printing directions.